### PR TITLE
fix typo + Error expectation; remove dupe Learn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,5 +448,3 @@ When you click on `lib/tic_tac_toe.rb`, you'll see something like:
 The lines in green have been tested, the lines in red haven't. When all tests pass, you should see 100% test coverage.
 
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/tic-tac-toe-rb' title='Tic Tac Toe in Ruby'>Tic Tac Toe in Ruby</a> on Learn.co and start learning to code for free.</p>
-
-<p class='util--hide'>View <a href='https://learn.co/lessons/tic-tac-toe-rb'>Tic Tac Toe in Ruby</a> on Learn.co and start learning to code for free.</p>

--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -43,7 +43,7 @@ describe './lib/tic_tac_toe.rb' do
 
   describe '#input_to_index' do
 
-    it 'convervets a user_input to an integer' do
+    it 'converts a user_input to an integer' do
       user_input = "1"
 
       expect(input_to_index(user_input)).to be_a(Integer)

--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -74,7 +74,7 @@ describe './lib/tic_tac_toe.rb' do
     it 'takes three arguments: board, position, and player token' do
       board = [" ", " ", " ", " ", " ", " ", " ", " ", " "]
 
-      expect{move(board, 0, "X")}.to_not raise_error(ArgumentError)
+      expect{move(board, 0, "X")}.to_not raise_error
     end
 
     it 'allows "X" player in the bottom right and "O" in the top left ' do


### PR DESCRIPTION
convervets --> convert

Also fixed error that caused `'takes three arguments: board, position, and player token'` to pass immediately, even prior to the creation of a `#move` method. The expectation would pass **unless** an `ArgumentError` was raised, including when another exception -- such as a `NoMethodError` -- was raised.
