### PR TITLE
Closes #51: Allow draw tests to handle different orders of won? and full?

### DIFF
--- a/spec/01_tic_tac_toe_spec.rb
+++ b/spec/01_tic_tac_toe_spec.rb
@@ -190,11 +190,17 @@ describe './lib/tic_tac_toe.rb' do
 
   describe '#draw?' do
 
-    it 'calls won? and full?' do
+    it 'calls won?' do
       board = ["X", "O", "X", "O", "X", "X", "O", "X", "O"]
-      expect(self).to receive(:won?).with(board)
-      expect(self).to receive(:full?).with(board)
 
+      expect(self).to receive(:won?).with(board)
+      draw?(board)
+    end
+
+    it 'calls full?' do 
+      board = ["X", "O", "X", "O", "X", "X", "O", "X", "O"]
+
+      expect(self).to receive(:full?).with(board)      
       draw?(board)
     end
 


### PR DESCRIPTION
Resolves #51 

@aturkewi, @kwebster2, @cjbrock @jmburges

Kevin just brought this one up in Slack today and I've also encountered it. I've had a few students working on this lab who implemented the draw? method in a slightly different way. It was clearly working properly (because it was calling both won? and full? and returning the correct values) but wasn't passing this test. 

Seems like splitting it off into two tests adds the flexibility needed to allow the tests to pass for different orders of calling won? and full?

For example, when this was just one test: 

```ruby
full?(board) && !won?(board) # fails
!won?(board) && full?(board) # passes
```
After this change:

```ruby
full?(board) && !won?(board) # passes both
!won?(board) && full?(board) # passes both
full?(board) == true && won?(board) == nil #passes both (if won? returns nil on non-winning board)
if full?(board) && !won?(board) 
  true 
else 
  false 
end
# also passes both
```

Before only a particular implementation would work.